### PR TITLE
Implementation of ScrollableStackView Component

### DIFF
--- a/DemoMaker.xcodeproj/project.pbxproj
+++ b/DemoMaker.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		AB1EE315271CAAB40075EAA2 /* DemoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1EE314271CAAB40075EAA2 /* DemoViewController.swift */; };
 		AB5E8AB52726502000BC73ED /* ControlsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB5E8AB42726502000BC73ED /* ControlsViewController.swift */; };
 		AB5E8AB72726577100BC73ED /* UIView+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB5E8AB62726577100BC73ED /* UIView+Ext.swift */; };
+		C3128086272BB4290008E6FB /* ScrollableStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3128085272BB4290008E6FB /* ScrollableStackView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -57,6 +58,7 @@
 		AB1EE314271CAAB40075EAA2 /* DemoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoViewController.swift; sourceTree = "<group>"; };
 		AB5E8AB42726502000BC73ED /* ControlsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlsViewController.swift; sourceTree = "<group>"; };
 		AB5E8AB62726577100BC73ED /* UIView+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Ext.swift"; sourceTree = "<group>"; };
+		C3128085272BB4290008E6FB /* ScrollableStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollableStackView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -109,6 +111,7 @@
 			children = (
 				C3128084272B35F60008E6FB /* Extensions */,
 				AB1EE314271CAAB40075EAA2 /* DemoViewController.swift */,
+				C3128085272BB4290008E6FB /* ScrollableStackView.swift */,
 				AB5E8AB42726502000BC73ED /* ControlsViewController.swift */,
 				AB1EE2E1271C91E90075EAA2 /* AppDelegate.swift */,
 				AB1EE2E3271C91E90075EAA2 /* SceneDelegate.swift */,
@@ -278,6 +281,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C3128086272BB4290008E6FB /* ScrollableStackView.swift in Sources */,
 				AB1EE2E6271C91E90075EAA2 /* ViewController.swift in Sources */,
 				AB1EE2E2271C91E90075EAA2 /* AppDelegate.swift in Sources */,
 				AB5E8AB52726502000BC73ED /* ControlsViewController.swift in Sources */,

--- a/DemoMaker/ControlsViewController.swift
+++ b/DemoMaker/ControlsViewController.swift
@@ -8,19 +8,7 @@
 import UIKit
 
 class ControlsViewController: UIViewController, UIScrollViewDelegate {
-
-    let scrollView: UIScrollView = {
-        let scrollView = UIScrollView()
-        return scrollView
-    }()
-
-    let buttonStack: UIStackView = {
-        let stack = UIStackView()
-        stack.axis = .horizontal
-        stack.alignment = .center
-        stack.distribution = .equalSpacing
-        return stack
-    }()
+    let controlsStack = ScrollableStackView(axis: .horizontal)
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -30,28 +18,32 @@ class ControlsViewController: UIViewController, UIScrollViewDelegate {
     
     func configure() {
         view.backgroundColor = .systemBackground
-        view.addSubview(buttonStack)
+        setupStack()
         addButtonsToStack()
-        setupConstraints()
     }
     
-    func addButtonsToStack() {
-        for i in 0..<5 {
-            let button = UIButton()
-            button.setTitle("Button \(i)", for: .normal)
-            button.setTitleColor(.systemBlue, for: .normal)
-            buttonStack.addArrangedSubview(button)
-            print("AddedButton")
+    private func addButtonsToStack() {
+        for _ in 0..<20 {
+            let image = UIImage(systemName: "pencil")
+            let imageView = UIImageView(image: image)
+            imageView.contentMode = .scaleAspectFit
+            controlsStack.stackView.addArrangedSubview(imageView)
         }
     }
     
-    func setupConstraints() {
-        buttonStack.translatesAutoresizingMaskIntoConstraints = false
+    func setupStack() {
+        view.addSubview(controlsStack)
+        controlsStack.stackView.distribution = .fillEqually
+        controlsStack.stackView.spacing = 40
+        // Makes it so that the stack view is horizontally scrollable
+        controlsStack.backgroundColor = .gray
+    
+        
         NSLayoutConstraint.activate([
-            buttonStack.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            buttonStack.centerYAnchor.constraint(equalTo: view.centerYAnchor),
-            buttonStack.widthAnchor.constraint(equalTo: view.widthAnchor),
-            buttonStack.heightAnchor.constraint(equalToConstant: 100)
+            controlsStack.widthAnchor.constraint(equalTo: view.widthAnchor),
+            controlsStack.heightAnchor.constraint(equalToConstant: 100),
+            controlsStack.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            controlsStack.centerXAnchor.constraint(equalTo: view.centerXAnchor)
         ])
     }
 }

--- a/DemoMaker/ScrollableStackView.swift
+++ b/DemoMaker/ScrollableStackView.swift
@@ -1,0 +1,59 @@
+//
+//  ScrollableStackView.swift
+//  DemoMaker
+//
+//  Created by Jonathan Yataco on 10/29/21.
+//
+
+import UIKit
+
+/// Reusuable view that manages a scrollable stack of views
+class ScrollableStackView: UIView {
+    let scrollView = UIScrollView()
+    let stackView = UIStackView()
+    
+    init(axis: NSLayoutConstraint.Axis) {
+        super.init(frame: .zero)
+        configure()
+        setAxis(axis)
+    }
+        
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func configure() {
+        translatesAutoresizingMaskIntoConstraints = false
+        addSubview(scrollView)
+        scrollView.addSubview(stackView)
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            scrollView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            scrollView.topAnchor.constraint(equalTo: self.topAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+            stackView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
+            stackView.topAnchor.constraint(equalTo: scrollView.topAnchor),
+            stackView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
+        ])
+    }
+    
+    /// Sets the axis/direction of the scrollable stack view
+    func setAxis(_ axis: NSLayoutConstraint.Axis) {
+        if axis == .horizontal {
+            stackView.axis = .horizontal
+            // Deactive the previous width anchor constraint if there was one
+            stackView.widthAnchor.constraint(equalTo: scrollView.widthAnchor).isActive = false
+            // Makes it so that the stack is only scrollable horizontally
+            stackView.heightAnchor.constraint(equalTo: scrollView.heightAnchor).isActive = true
+        } else {
+            stackView.axis = .vertical
+            // Deactive the previous height anchor constraint if there was one
+            stackView.heightAnchor.constraint(equalTo: scrollView.heightAnchor).isActive = false
+            // Makes it so that the stack is only scrollable vertically
+            stackView.widthAnchor.constraint(equalTo: scrollView.widthAnchor).isActive = true
+        }
+    }
+}


### PR DESCRIPTION
This component uses a UIScrollView and a UIStackView under the hood, and allows the caller to initialize it with a given `NSLayoutConstraint.Axis.

To add items to the underlying `stackView`, simply access it and use the `addArrangedSubView` method. The `stackView` and `scrollView` are public properties so the stackView or scrollView properties can be configured.